### PR TITLE
🔧 Fix NPM group naming

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: 'monthly'
     groups:
-      actions:
+      npm:
         patterns:
           - '*'
     commit-message:


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` file to modify the dependency group configuration.